### PR TITLE
Potential fix for code scanning alert no. 1: Useless regular-expression character escape

### DIFF
--- a/lsp/server/src/server.ts
+++ b/lsp/server/src/server.ts
@@ -249,7 +249,7 @@ function taskFileParser(yamlData: any, model: any) {
 function setDiagnostics(repoUrlAndVersion: { [key: string]: any }, textDocument: TextDocument, diagnostics: Diagnostic[], seen: Set<string>, err_type: string) {
   const text = textDocument.getText();
   const url = repoUrlAndVersion['link'];
-  let escapedUrl = url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + "\\s+v\\d\.*";
+  let escapedUrl = url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + "\\s+v\\d\\.*";
   const regex = new RegExp(escapedUrl, 'g');
   let match: RegExpExecArray | null;
   while ((match = regex.exec(text)) !== null) {


### PR DESCRIPTION
Potential fix for [https://github.com/boschglobal/dse.sdp/security/code-scanning/1](https://github.com/boschglobal/dse.sdp/security/code-scanning/1)

The best way to fix the problem is to ensure that when appending substrings that intend to include a literal dot in a regular expression pattern string (for `new RegExp()`), the dot is properly escaped by using `"\\."` in the string literal. In this code, on line 252, `escapedUrl` is built by concatenating the escaped URL (`url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')`) with `"\\s+v\\d\.*"`. The string `"\\d\.*"` is problematic: `\.` is not a valid escape and will be interpreted as `.`, so a single backslash in the string literal does not escape the dot in RegExp; two backslashes are needed.

Change those lines so that the appended substring is `"\\s+v\\d\\.*"` (with two backslashes before the dot), ensuring that the resulting pattern properly matches a literal dot after the `"v<digits>"` version, such as `"v1.2"`.

Edit only line 252 in lsp/server/src/server.ts by replacing `"\\s+v\\d\.*"` with `"\\s+v\\d\\.*"`. No new imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
