### PR TITLE
feat: enhance simulation generation and taskfile handling (#32)

### DIFF
--- a/ast/internal/app/generate/metadata_lookup.go
+++ b/ast/internal/app/generate/metadata_lookup.go
@@ -1,0 +1,143 @@
+// Copyright 2025 Robert Bosch GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package generate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/boschglobal/dse.schemas/code/go/dse/ast"
+)
+
+func metadataQuery(keys ...string) string {
+	return "metadata/" + strings.Join(keys, "/")
+}
+
+func logMissingMetadata(required bool, query, uri, uses string, defaultValue interface{}) {
+	if required {
+		fmt.Fprintf(os.Stderr, "[Error] Item not found! query=%s, uri=%s, uses=%s\n", query, uri, uses)
+		return
+	}
+	fmt.Fprintf(os.Stdout, "[Info] Item not found, using default (%v). query=%s, uri=%s, uses=%s\n", defaultValue, query, uri, uses)
+}
+
+func lookupMetadataValue(md map[string]interface{}, keys ...string) (interface{}, bool) {
+	var node interface{} = md
+	for _, key := range keys {
+		m, ok := node.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		v, ok := m[key]
+		if !ok {
+			return nil, false
+		}
+		node = v
+	}
+	return node, true
+}
+
+func requiredMetadataString(md map[string]interface{}, uses ast.Uses, keys ...string) (string, error) {
+	query := metadataQuery(keys...)
+	uri := taskfileURIForUses(uses)
+	value, ok := lookupMetadataValue(md, keys...)
+	if !ok {
+		logMissingMetadata(true, query, uri, uses.Name, "")
+		return "", fmt.Errorf("missing metadata: %s", query)
+	}
+	s, ok := value.(string)
+	if !ok || s == "" {
+		logMissingMetadata(true, query, uri, uses.Name, "")
+		return "", fmt.Errorf("missing metadata: %s", query)
+	}
+	return s, nil
+}
+
+func optionalMetadataBool(md map[string]interface{}, uses ast.Uses, defaultValue bool, keys ...string) bool {
+	query := metadataQuery(keys...)
+	uri := taskfileURIForUses(uses)
+	value, ok := lookupMetadataValue(md, keys...)
+	if !ok {
+		logMissingMetadata(false, query, uri, uses.Name, defaultValue)
+		return defaultValue
+	}
+	b, ok := value.(bool)
+	if !ok {
+		logMissingMetadata(false, query, uri, uses.Name, defaultValue)
+		return defaultValue
+	}
+	return b
+}
+
+func optionalMetadataSlice(md map[string]interface{}, uses ast.Uses, defaultValue []interface{}, keys ...string) []interface{} {
+	query := metadataQuery(keys...)
+	uri := taskfileURIForUses(uses)
+	value, ok := lookupMetadataValue(md, keys...)
+	if !ok {
+		logMissingMetadata(false, query, uri, uses.Name, defaultValue)
+		return defaultValue
+	}
+	slice, ok := value.([]interface{})
+	if !ok {
+		logMissingMetadata(false, query, uri, uses.Name, defaultValue)
+		return defaultValue
+	}
+	return slice
+}
+
+func taskfileURIForUses(uses ast.Uses) string {
+	if uses.Url == "" {
+		return ""
+	}
+	u, err := urlEscapedParse(uses.Url)
+	if err != nil {
+		return uses.Url
+	}
+	switch u.Scheme {
+	case "file":
+		path := u.Path
+		if path == "" {
+			return uses.Url
+		}
+		if info, err := os.Stat(path); err == nil && info.IsDir() {
+			for _, name := range []string{"Taskfile.yml", "Taskfile.yaml"} {
+				candidate := filepath.Join(path, name)
+				if _, err := os.Stat(candidate); err == nil {
+					return "file://" + candidate
+				}
+			}
+			return "file://" + filepath.Join(path, "Taskfile.yml")
+		}
+		if strings.HasSuffix(path, "Taskfile.yml") || strings.HasSuffix(path, "Taskfile.yaml") {
+			return "file://" + path
+		}
+		return uses.Url
+	case "https":
+		if uses.Version == nil {
+			return uses.Url
+		}
+		if !strings.HasPrefix(u.Host, "github.") {
+			return uses.Url
+		}
+		pathParts := strings.Split(u.Path, string(os.PathSeparator))
+		if len(pathParts) < 3 {
+			return uses.Url
+		}
+		owner := pathParts[1]
+		repo := pathParts[2]
+		switch u.Host {
+		case "github.com":
+			return fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/refs/tags/%s/Taskfile.yml", owner, repo, *uses.Version)
+		case "github.boschdevcloud.com":
+			return fmt.Sprintf("https://raw.github.boschdevcloud.com/%s/%s/%s/Taskfile.yml", owner, repo, *uses.Version)
+		default:
+			return uses.Url
+		}
+	default:
+		return uses.Url
+	}
+}

--- a/ast/internal/app/generate/simulation.go
+++ b/ast/internal/app/generate/simulation.go
@@ -132,6 +132,15 @@ func (c *GenerateCommand) GenerateSimulation() error {
 		}
 		for _, astModel := range astStack.Models {
 			mcl := getMclType(astModel.Model, simSpec.Uses)
+			modelUses := ast.Uses{}
+			if len(astModel.Uses) > 0 && simSpec.Uses != nil {
+				for _, uses := range *simSpec.Uses {
+					if uses.Name == astModel.Uses {
+						modelUses = uses
+						break
+					}
+				}
+			}
 			channels := []kind.Channel{}
 			for _, c := range astModel.Channels {
 				if slices.Contains(simChannels, c.Name) {
@@ -149,15 +158,9 @@ func (c *GenerateCommand) GenerateSimulation() error {
 			if astModel.Metadata != nil {
 				md = *astModel.Metadata
 			}
-			func() {
-				defer func() {
-					if r := recover(); r != nil {
-					}
-				}()
-				if md["models"].(map[string]interface{})[astModel.Model].(map[string]interface{})["mcl"].(bool) == true {
-					modelName = astModel.Name
-				}
-			}()
+			if optionalMetadataBool(md, modelUses, false, "models", astModel.Model, "mcl") {
+				modelName = astModel.Name
+			}
 			var annotationMap map[string]interface{}
 			if astModel.Annotations != nil && len(*astModel.Annotations) > 0 {
 				annotationMap = make(map[string]interface{})

--- a/ast/internal/app/generate/taskfile_model.go
+++ b/ast/internal/app/generate/taskfile_model.go
@@ -25,6 +25,7 @@ func urlEscapedParse(u string) (*url.URL, error) {
 }
 
 func resolveRemoteTaskfile(u *url.URL, owner, repo, version string) string {
+	var fallback string
 	for _, name := range []string{"Taskfile.yml", "Taskfile.yaml"} {
 		resolvedURL := *u
 		var finalUrl *url.URL
@@ -49,14 +50,26 @@ func resolveRemoteTaskfile(u *url.URL, owner, repo, version string) string {
 
 		req, _ := http.NewRequest(http.MethodHead, probeUrl, nil)
 		resp, err := http.DefaultClient.Do(req)
-		if err == nil && resp.StatusCode == http.StatusOK {
-			_u := finalUrl.String()
-			_u = strings.ReplaceAll(_u, `%7B`, `{`)
-			_u = strings.ReplaceAll(_u, `%7D`, `}`)
+		_u := finalUrl.String()
+		_u = strings.ReplaceAll(_u, `%7B`, `{`)
+		_u = strings.ReplaceAll(_u, `%7D`, `}`)
+		if fallback == "" {
+			fallback = _u
+		}
+		if err != nil {
+			return _u
+		}
+		if resp != nil {
+			resp.Body.Close()
+		}
+		if resp.StatusCode == http.StatusOK {
+			return _u
+		}
+		if resp.StatusCode != http.StatusNotFound {
 			return _u
 		}
 	}
-	return ""
+	return fallback
 }
 
 func (c GenerateCommand) buildIncludes() map[string]Include {
@@ -283,7 +296,7 @@ func resolveMclFromUses(u ast.Uses) (MclInfo, bool) {
 	return MclInfo{Type: ""}, false
 }
 
-func genericModelTask(model ast.Model, modelUses ast.Uses) Task {
+func genericModelTask(model ast.Model, modelUses ast.Uses) (Task, error) {
 	mcl, _ := resolveMclFromUses(modelUses)
 	modelUrl, _ := urlEscapedParse(modelUses.Url)
 	cmds := []Cmd{
@@ -315,16 +328,32 @@ func genericModelTask(model ast.Model, modelUses ast.Uses) Task {
 			"downloads/{{base .PACKAGE_URL}}",
 		}
 	}()
+	pkgUrlKey := "download"
+	if modelUrl.Scheme == "file" && mcl.Type != "lua" {
+		pkgUrlKey = "file"
+	}
 	md := map[string]interface{}{}
 	if model.Metadata != nil {
 		md = *model.Metadata
+	}
+	var packageURL string
+	var packagePath string
+	if mcl.Type == "" {
+		var err error
+		packageURL, err = requiredMetadataString(md, modelUses, "package", pkgUrlKey)
+		if err != nil {
+			return Task{}, err
+		}
+		packagePath, err = requiredMetadataString(md, modelUses, "models", model.Model, "path")
+		if err != nil {
+			return Task{}, err
+		}
 	}
 
 	modelTask := Task{
 		Dir:   util.StringPtr("{{.OUTDIR}}"),
 		Label: util.StringPtr(fmt.Sprintf("sim:model:%s", model.Name)),
 		Vars: func() *OMap {
-			pkgUrlKey := "download"
 			repo := modelUses.Url
 			u, _ := url.Parse(repo)
 			if modelUrl.Scheme == "file" {
@@ -332,7 +361,6 @@ func genericModelTask(model ast.Model, modelUses ast.Uses) Task {
 				if mcl.Type == "lua" { // eg u.Path : /mnt/c/Users/hello.lua
 					repo = filepath.Dir(u.Path)
 				} else {
-					pkgUrlKey = "file"
 					repo = strings.TrimSuffix(modelUrl.Path, "/") // eg modelUrl.Path : /mnt/c/Users/dse.sdp/
 				}
 			}
@@ -358,25 +386,19 @@ func genericModelTask(model ast.Model, modelUses ast.Uses) Task {
 				om.Set("PLATFORM_ARCH", *model.Arch)
 			}
 
-			func() {
-				defer func() {
-					if r := recover(); r != nil {
-					}
-				}()
-				switch mcl.Type {
-				case "lua":
-					if modelUrl.Scheme == "file" {
-						om.Set("PACKAGE_URL", filepath.Base(u.Path))
-						om.Set("PACKAGE_PATH", mcl.Path)
-					} else if modelUrl.Scheme == "https" {
-						om.Set("PACKAGE_URL", mcl.Url)
-						om.Set("PACKAGE_PATH", mcl.Path)
-					}
-				case "":
-					om.Set("PACKAGE_URL", md["package"].(map[string]interface{})[pkgUrlKey].(string))
-					om.Set("PACKAGE_PATH", md["models"].(map[string]interface{})[model.Model].(map[string]interface{})["path"].(string))
+			switch mcl.Type {
+			case "lua":
+				if modelUrl.Scheme == "file" {
+					om.Set("PACKAGE_URL", filepath.Base(u.Path))
+					om.Set("PACKAGE_PATH", mcl.Path)
+				} else if modelUrl.Scheme == "https" {
+					om.Set("PACKAGE_URL", mcl.Url)
+					om.Set("PACKAGE_PATH", mcl.Path)
 				}
-			}()
+			case "":
+				om.Set("PACKAGE_URL", packageURL)
+				om.Set("PACKAGE_PATH", packagePath)
+			}
 
 			return &om
 		}(),
@@ -385,7 +407,7 @@ func genericModelTask(model ast.Model, modelUses ast.Uses) Task {
 		Sources:   &sources,
 		Generates: &generates,
 	}
-	return modelTask
+	return modelTask, nil
 }
 
 func parseUrl(task *Task, uses *ast.Uses, modelName string) string {
@@ -471,13 +493,17 @@ func buildModel(model ast.Model, simSpec ast.SimulationSpec) (Task, error) {
 			return Task{}, fmt.Errorf("Model uses not found in simulation AST (name=%s)", model.Uses)
 		}
 	}
+	mcl, _ := resolveMclFromUses(modelUses)
 	usesDownloadFilePaths := map[string]string{}
 
 	md := map[string]interface{}{}
 	if model.Metadata != nil {
 		md = *model.Metadata
 	}
-	modelTask := genericModelTask(model, modelUses)
+	modelTask, err := genericModelTask(model, modelUses)
+	if err != nil {
+		return Task{}, err
+	}
 
 	// Parse: user files
 	func(task *Task, model ast.Model) {
@@ -538,18 +564,7 @@ func buildModel(model ast.Model, simSpec ast.SimulationSpec) (Task, error) {
 
 	// Parse: modelc package/model files
 	func(task *Task, model ast.Model) {
-		isModel := func() bool {
-			defer func() {
-				if r := recover(); r != nil {
-				}
-			}()
-			if v := md["models"].(map[string]interface{})[model.Model].(map[string]interface{})["path"]; v != nil {
-				return true
-			} else {
-				return false
-			}
-		}
-		if isModel() == false {
+		if mcl.Type == "lua" {
 			return
 		}
 		*task.Cmds = append(*task.Cmds, Cmd{
@@ -711,9 +726,9 @@ func buildModel(model ast.Model, simSpec ast.SimulationSpec) (Task, error) {
 					if r := recover(); r != nil {
 					}
 				}()
-				workflowFiles = md["tasks"].(map[string]interface{})[workflow.Name].(map[string]interface{})["generates"].([]interface{})
-			}()
-			for _, file := range workflowFiles {
+			workflowFiles = optionalMetadataSlice(md, modelUses, []interface{}{}, "tasks", workflow.Name, "generates")
+		}()
+		for _, file := range workflowFiles {
 				*task.Generates = append(*task.Generates, fmt.Sprintf("{{.SIMDIR}}/{{.PATH}}/%s", file.(string)))
 			}
 		}

--- a/ast/internal/app/generate/taskfile_test.go
+++ b/ast/internal/app/generate/taskfile_test.go
@@ -5,6 +5,7 @@
 package generate
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -25,6 +26,53 @@ func generateTaskfile(t *testing.T, input string) string {
 	assert.NoError(t, err)
 
 	return taskfileName
+}
+
+func captureOutput(t *testing.T, fn func() error) (string, string, error) {
+	t.Helper()
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	require.NoError(t, err)
+	stderrReader, stderrWriter, err := os.Pipe()
+	require.NoError(t, err)
+
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	os.Stdout = stdoutWriter
+	os.Stderr = stderrWriter
+
+	outCh := make(chan string)
+	errCh := make(chan string)
+	go func() {
+		b, _ := io.ReadAll(stdoutReader)
+		outCh <- string(b)
+	}()
+	go func() {
+		b, _ := io.ReadAll(stderrReader)
+		errCh <- string(b)
+	}()
+
+	runErr := fn()
+	stdoutWriter.Close()
+	stderrWriter.Close()
+	os.Stdout = origStdout
+	os.Stderr = origStderr
+
+	stdout := <-outCh
+	stderr := <-errCh
+	return stdout, stderr, runErr
+}
+
+func generateTaskfileWithOutput(t *testing.T, input string) (string, string, string, error) {
+	var outFolder = t.TempDir()
+	var taskfileName = filepath.Join(outFolder, "Taskfile.yml")
+	cmd := NewGenerateCommand("test_generate_taskfile_output")
+	args := []string{"-taskfile", "-input", input, "-output", outFolder}
+
+	err := cmd.Parse(args)
+	require.NoError(t, err)
+
+	stdout, stderr, runErr := captureOutput(t, cmd.Run)
+	return taskfileName, stdout, stderr, runErr
 }
 
 func TestGenerateTaskfile_global_vars(t *testing.T) {
@@ -246,4 +294,24 @@ func TestGenerateTaskfile_model_fmu(t *testing.T) {
 
 	YamlContains(t, f, "$.tasks.model-linear.generates[4]", "{{.SIMDIR}}/{{.PATH}}/data/model.yaml")
 	YamlContains(t, f, "$.tasks.model-linear.generates[5]", "{{.SIMDIR}}/{{.PATH}}/data/signalgroup.yaml")
+}
+
+func TestGenerateTaskfile_missing_required_metadata(t *testing.T) {
+	_, stdout, stderr, runErr := generateTaskfileWithOutput(t, "testdata/ast__model_missing_package.yaml")
+	require.Error(t, runErr)
+
+	logOutput := stdout + stderr
+	assert.Contains(t, logOutput, "[Error] Item not found! query=metadata/package/download")
+	assert.Contains(t, logOutput, "uses=dse.modelc")
+}
+
+func TestGenerateTaskfile_missing_optional_generates(t *testing.T) {
+	taskfileName, stdout, stderr, runErr := generateTaskfileWithOutput(t, "testdata/ast__model_fmu_missing_generates.yaml")
+	require.NoError(t, runErr)
+	assert.FileExists(t, taskfileName)
+
+	logOutput := stdout + stderr
+	assert.Contains(t, logOutput, "[Info] Item not found, using default ([])")
+	assert.Contains(t, logOutput, "query=metadata/tasks/generate-fmimcl/generates")
+	assert.Contains(t, logOutput, "uses=dse.fmi")
 }

--- a/ast/internal/app/generate/testdata/ast.yaml
+++ b/ast/internal/app/generate/testdata/ast.yaml
@@ -22,6 +22,7 @@ spec:
               name: network
           model: dse.fmi.mcl
           name: FMU
+          uses: dse.fmi
           workflows:
             - name: generate
               vars:
@@ -30,6 +31,18 @@ spec:
                   value: fmu
                 - name: model_key
                   value: model_val
+          metadata:
+            package:
+              download: '{{.REPO}}/releases/download/v{{.TAG}}/Fmi-{{.TAG}}-{{.PLATFORM_ARCH}}.zip'
+            models:
+              dse.fmi.mcl:
+                path: fmimcl
+                mcl: true
+            tasks:
+              generate:
+                generates:
+                  - data/model.yaml
+                  - data/signalgroup.yaml
       name: default
   uses:
     - name: dse.fmi

--- a/ast/internal/app/generate/testdata/ast__model_fmu_missing_generates.yaml
+++ b/ast/internal/app/generate/testdata/ast__model_fmu_missing_generates.yaml
@@ -1,0 +1,43 @@
+---
+kind: Simulation
+spec:
+  arch: linux-amd64
+  channels:
+    - name: physical
+  stacks:
+    - name: default
+      models:
+        - name: linear
+          model: dse.fmi.mcl
+          uses: dse.fmi
+          channels:
+            - alias: scalar_vector
+              name: physical
+          workflows:
+            - name: generate-fmimcl
+              vars:
+                - name: FMU_DIR
+                  reference: uses
+                  value: linear_fmu
+                - name: OUT_DIR
+                  value: '{{.PATH}}/data'
+                - name: MCL_PATH
+                  value: '{{.PATH}}/lib/libfmimcl.so'
+          metadata:
+            package:
+              download: '{{.REPO}}/releases/download/v{{.TAG}}/Fmi-{{.TAG}}-{{.PLATFORM_ARCH}}.zip'
+            models:
+              dse.fmi.mcl:
+                path: fmimcl
+                mcl: true
+  uses:
+    - name: dse.fmi
+      url: https://github.com/boschglobal/dse.fmi
+      version: v1.1.20
+      metadata:
+        container:
+          repository: ghcr.io/boschglobal/dse-fmi
+    - name: linear_fmu
+      url: https://github.com/boschglobal/dse.fmi/releases/download/v1.1.20/Fmi-1.1.20-linux-amd64.zip
+      path: examples/fmu/linear/fmi2/linear.fmu
+      metadata: {}

--- a/ast/internal/app/generate/testdata/ast__model_missing_package.yaml
+++ b/ast/internal/app/generate/testdata/ast__model_missing_package.yaml
@@ -1,0 +1,26 @@
+---
+kind: Simulation
+spec:
+  arch: linux-amd64
+  channels:
+    - name: physical
+  stacks:
+    - name: default
+      models:
+        - name: input
+          model: dse.modelc.csv
+          uses: dse.modelc
+          channels:
+            - alias: scalar_vector
+              name: physical
+          metadata:
+            models:
+              dse.modelc.csv:
+                path: examples/csv
+  uses:
+    - name: dse.modelc
+      url: https://github.com/boschglobal/dse.modelc
+      version: v2.1.15
+      metadata:
+        container:
+          repository: ghcr.io/boschglobal/dse-modelc


### PR DESCRIPTION
## Problem statement
Missing metadata keys in Taskfile generation were silently ignored due to unchecked type assertions wrapped in recover blocks. This made misconfigurations hard to spot and could produce incomplete taskfiles without clear signals.

## Root cause
Metadata access used direct map assertions inside `recover()` closures, which swallowed type/key errors and prevented any explicit logging or error propagation.

## Implementation details
- Added metadata lookup helpers to:
  - detect missing keys,
  - emit required/optional log lines in the requested format,
  - return defaults for optional fields, and
  - error out for required fields.
- Required metadata for package URL/path now fails fast with clear error logs.
- Optional metadata (e.g., workflow generates, mcl flag) now logs info and uses defaults.
- Ensured includes still resolve by using a deterministic fallback Taskfile URL when remote HEAD checks fail.
- Updated test fixtures to include required metadata where needed and added targeted tests for required/optional behavior.

## Logging examples
### Before
- Missing metadata caused a silent recovery with no actionable log.

### After
- Required missing key:
  ```
  [Error] Item not found! query=metadata/package/file, uri=file:///repo/Taskfile.yml, uses=dse.fmi
  ```
- Optional missing key:
  ```
  [Info] Item not found, using default (). query=metadata/package/file, uri=file:///repo/Taskfile.yml, uses=dse.fmi
  ```