### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -6,6 +6,10 @@ on:  # yamllint disable-line rule:truthy
 #    tags:
 #      - 'v*.*.*'
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   run:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/boschglobal/dse.sdp/security/code-scanning/2](https://github.com/boschglobal/dse.sdp/security/code-scanning/2)

To fix this, add an explicit top-level `permissions` block in `.github/workflows/examples.yaml` so the workflow does not inherit potentially over-privileged defaults.

Best single fix (without changing functionality): add minimal read-only permissions at the workflow root:
- `contents: read`
- `packages: read`

This applies to all jobs in this workflow unless overridden and documents intended token scope. Place this block after the trigger section (`on:`) and before `jobs:`.

No imports, methods, or extra definitions are needed—just YAML key additions in the shown file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
